### PR TITLE
Fixed small typo on homepage

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -16,7 +16,7 @@ const FeatureList = [
         The goal of COMPSCI220 Programming Methodology is to turn you into an advanced programmer with a deep
         understanding of modern programming methodology. We will emphasize good software engineering skills, 
         including programming abstractions, testing, and debugging. Although the programming languages that we 
-        will use are JavaScript and TypeScript, we will emphasize general programming principles. Every- thing 
+        will use are JavaScript and TypeScript, we will emphasize general programming principles. Everything 
         that you will learn in the class will be applicable to other modern languages, including (for example)
         C++, C#, D, Go, Java, Python, Rust, and Swift.
         </div>


### PR DESCRIPTION
I noticed that there was a small typo on the home page. I changed "Every- thing that you will learn in the class..." to "Everything that you will learn in the class...".